### PR TITLE
fix: correção nos links para o repositório do CCUFFS.

### DIFF
--- a/_posts/noticias/2020-10-13-hacktoberfest-2020.md
+++ b/_posts/noticias/2020-10-13-hacktoberfest-2020.md
@@ -19,7 +19,7 @@ Se você é novo com git, não há problema! O hacktoberfest é uma excelente op
 
 Cada contribuição que você fizer durante o mês de outubro rederá um prêmio. Esse ano, temos mais premiações! Você pode ganhar adesivos dev geek, que ficam lindos no seu notebook, ou até uma camiseta única do evento.
 
-Você ganha esses prêmios por cada nova _issue_ ou _pull request_ emitidos em seu nome para qualquer um dos repositórios do curso listados em [https://github.com/ccuffs](github.com/ccuffs). Para  garantir  que  todos  tenham  chance  de  ganhar  algo,  os  prêmios  serão  dados da seguinte forma: 
+Você ganha esses prêmios por cada nova _issue_ ou _pull request_ emitidos em seu nome para qualquer um dos repositórios do curso listados em [https://github.com/ccuffs](https://github.com/ccuffs). Para  garantir  que  todos  tenham  chance  de  ganhar  algo,  os  prêmios  serão  dados da seguinte forma: 
 
 {:.table}
 | AÇÃO  | PREMIAÇÃO * |
@@ -29,7 +29,7 @@ Você ganha esses prêmios por cada nova _issue_ ou _pull request_ emitidos em s
 | Criar um pull request que resolve uma issue marcada como `hacktoberfest` | 1 camiseta personalizada Hacktoberfest 2020 CC UFFS |
 |||
 
-> *= As contribuições precisam ser feitas nos repositórios listados em [https://github.com/ccuffs](github.com/ccuffs), mesmo que esses sejam forks. Issues novas precisam ser, pelo menos, relacionadas com o repositório onde foram abertas. 
+> *= As contribuições precisam ser feitas nos repositórios listados em [https://github.com/ccuffs](https://github.com/ccuffs), mesmo que esses sejam forks. Issues novas precisam ser, pelo menos, relacionadas com o repositório onde foram abertas. 
 
 ![Adesivos](/images/posts/stickers.png)
 


### PR DESCRIPTION
Correção de erros nos links do site do CCUFFS.

Devido a falta de `https://` no endereço, ambos redirecionavam o usuário para `https://cc.uffs.edu.br/noticias/2020/10/13/hacktoberfest-2020/github.com/ccuffs`.

Caso seja necessário qualquer outro ajuste, ficarei feliz em realizar.