### PR TITLE
correção do típico da CCR GEX112 - Optativa

### DIFF
--- a/_posts/noticias/2022-08-08-horarios-2022-2.md
+++ b/_posts/noticias/2022-08-08-horarios-2022-2.md
@@ -37,7 +37,7 @@ Pilares da Segurança; Criptografia; Protocolos; Blockchain; Funções Hash; Fal
 As aulas serão expositivas e na forma de debate, e serão organizadas propiciando discussões e contextualização entre conceitos teóricos e problemas práticos reais e/ou simulados. A organização e a estratégia empregadas em aula terão como objetivo o aprendizado do estudante, fazendo assim que o componente curricular evolua nos conceitos necessários considerando as dificuldades enfrentadas em cada um dos conteúdos programáticos.
 
 **Conhecimentos prévios necessários:**
-Progamação 2
+Programação 2
 
 ---
 


### PR DESCRIPTION
Em parte de conhecimentos prévios necessários está escrito "Progamação 2",   e deveria ser  "Programação 2".