### PR TITLE
feat: inclui as pré-configurações para utilizar o Google Analytics

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,11 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-XXXXXXXXXX');
+</script>
+
+<!-- EM G-XXXXXXXXXX INCLUIR O ID DE RASTREAMENTO GERADO AO CRIAR A CONTA DO G-ANALYTICS -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    {% include analytics.html %}
     <meta charset="utf-8">
     <title>{% if page.title %}{{ page.title }} • {% endif %}{{ site.title }}</title>
     {% if page.excerpt %}<meta name="description" content="{{ page.excerpt | strip_html }}">{% endif %}


### PR DESCRIPTION
### Este commit resolve a Issue #13  (Ativar o Google Analytics).

Ele inclui no site as **pré-configurações** para o funcionamento do *Google Analytics*. Trata-se uma pré-configuração pois para o pleno funcionamento deve ser vinculado o **ID de Rastreamento** no arquivo `_includes/analytics.html`. *(O ID de rastreamento é gerado ao criar uma conta no Google Analytics).*

Closes #13 
